### PR TITLE
Bug Fix/ removing onChange from firing too often

### DIFF
--- a/src/components/CountrySelectAdapter.tsx
+++ b/src/components/CountrySelectAdapter.tsx
@@ -14,24 +14,26 @@ type Props = {
   value?: string;
 } & Omit<ComponentProps<typeof SelectInput>, 'onChange' | 'options' | 'value'>;
 
-export const CountrySelectAdapter = ({ value, options = [], onChange, iconComponent, ...props }: Props) => {
+export const CountrySelectAdapter = ({
+  value,
+  options = [],
+  onChange,
+  iconComponent,
+  ...props
+}: Props) => {
   const Icon = iconComponent;
   const [rawValue, setRawValue] = useState<Value>(
     options.find((option) => option.value === value) || null
   );
 
   useEffect(() => {
-    setRawValue(options.find((option) => option.value === value) || null);
+    const rawValue = options.find((option) => option.value === value) || null;
+    setRawValue(rawValue);
   }, [value, options]);
-
-  useEffect(() => {
-    if (rawValue) {
-      onChange(rawValue.value);
-    }
-  }, [rawValue, onChange]);
 
   const handleChange = (newValue: unknown) => {
     setRawValue(newValue as Value);
+    onChange((newValue as Value)?.value || "");
   };
 
   const formatOptionLabel = (data: unknown) => {


### PR DESCRIPTION
## Bug Description
Unable to use plugin. Any project that uses it, will face this issue

## Bug reason
Upon saving the record, `CountrySelectorAdapter.tsx` fires an `onChange` event twice, resetting the phone number to the default prefix of the selected country.

## Bug fix
I suggest removing an unnecesary useEffect. It is probably better for efficiency too.