### PR TITLE
fix: dropdown gaps

### DIFF
--- a/src/components/CountrySelectAdapter.tsx
+++ b/src/components/CountrySelectAdapter.tsx
@@ -14,7 +14,7 @@ type Props = {
   value?: string;
   onMenuOpen?: () => void;
   onMenuClose?: () => void;
-} & Omit<ComponentProps<typeof SelectInput>, 'onChange' | 'options' | 'value'>;
+} & Omit<ComponentProps<typeof SelectInput>, "onChange" | "options" | "value">;
 
 export const CountrySelectAdapter = ({
   value,
@@ -27,12 +27,12 @@ export const CountrySelectAdapter = ({
 }: Props) => {
   const Icon = iconComponent;
   const [rawValue, setRawValue] = useState<Value>(
-    options.find((option) => option.value === value) || null
+    options.find((option) => option.value === value) || null,
   );
 
   useEffect(() => {
-    const found = options.find((option) => option.value === value) || null;
-    setRawValue(found);
+    const rawValue = options.find((option) => option.value === value) || null;
+    setRawValue(rawValue);
   }, [value, options]);
 
   const handleChange = (newValue: unknown) => {
@@ -40,7 +40,6 @@ export const CountrySelectAdapter = ({
     setRawValue(val);
     onChange(val?.value || "");
 
-    // Ensure the iframe resets height immediately after selection
     if (onMenuClose) onMenuClose();
   };
 

--- a/src/components/CountrySelectAdapter.tsx
+++ b/src/components/CountrySelectAdapter.tsx
@@ -12,6 +12,8 @@ type Props = {
   iconComponent: ElementType;
   options?: OptionType[];
   value?: string;
+  onMenuOpen?: () => void;
+  onMenuClose?: () => void;
 } & Omit<ComponentProps<typeof SelectInput>, 'onChange' | 'options' | 'value'>;
 
 export const CountrySelectAdapter = ({
@@ -19,6 +21,8 @@ export const CountrySelectAdapter = ({
   options = [],
   onChange,
   iconComponent,
+  onMenuOpen,
+  onMenuClose,
   ...props
 }: Props) => {
   const Icon = iconComponent;
@@ -27,13 +31,17 @@ export const CountrySelectAdapter = ({
   );
 
   useEffect(() => {
-    const rawValue = options.find((option) => option.value === value) || null;
-    setRawValue(rawValue);
+    const found = options.find((option) => option.value === value) || null;
+    setRawValue(found);
   }, [value, options]);
 
   const handleChange = (newValue: unknown) => {
-    setRawValue(newValue as Value);
-    onChange((newValue as Value)?.value || "");
+    const val = newValue as Value;
+    setRawValue(val);
+    onChange(val?.value || "");
+
+    // Ensure the iframe resets height immediately after selection
+    if (onMenuClose) onMenuClose();
   };
 
   const formatOptionLabel = (data: unknown) => {
@@ -53,6 +61,8 @@ export const CountrySelectAdapter = ({
       onChange={handleChange}
       options={options}
       formatOptionLabel={formatOptionLabel}
+      onMenuOpen={onMenuOpen}
+      onMenuClose={onMenuClose}
       {...props}
     />
   );

--- a/src/entrypoints/FieldExtension.tsx
+++ b/src/entrypoints/FieldExtension.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { RenderFieldExtensionCtx } from "datocms-plugin-sdk";
 import { Canvas, FieldError } from "datocms-react-ui";
 import getValue from "../lib/get-value";
@@ -19,44 +19,55 @@ type Props = {
 };
 
 export default function FieldExtension({ ctx }: Props) {
+  const { setHeight, startAutoResizer, stopAutoResizer } = ctx;
   const parameters = ctx.parameters as Parameters;
   const fieldType = ctx.field.attributes.field_type;
+
   const [rawValue] = useState<string | undefined>(
     getValue<string>(ctx.formValues, ctx.fieldPath),
   );
   const [value, setValue] = useState<string>();
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  /**
+   * Manually manage iframe height when the country dropdown opens.
+   */
+  const handleMenuOpen = useCallback(() => {
+    if (containerRef.current) {
+      const currentHeight = containerRef.current.getBoundingClientRect().height;
+
+      stopAutoResizer();
+
+      setHeight(Math.max(currentHeight, 360) + 10);
+    }
+  }, [stopAutoResizer, setHeight]);
+
+  const handleMenuClose = useCallback(() => {
+    startAutoResizer();
+  }, [startAutoResizer]);
+
   const countries = getCountries().filter((country) => {
     const include = parameters.includeCountries;
     const exclude = parameters.excludeCountries;
 
-    if (include && !include.find((item) => item.value === country)) {
-      return false;
-    }
-
-    if (exclude && exclude.find((item) => item.value === country)) {
-      return false;
-    }
+    if (include && !include.find((item) => item.value === country)) return false;
+    if (exclude && exclude.find((item) => item.value === country)) return false;
 
     return true;
   });
 
   const handleChange = async (newValue: string | undefined) => {
-    if (newValue && !isValidPhoneNumber(String(newValue))) {
-      ctx.updatePluginParameters({
-        ...ctx.plugin.attributes.parameters,
-        [ctx.field.id]: { invalid: true },
-      });
-    } else {
-      ctx.updatePluginParameters({
-        ...ctx.plugin.attributes.parameters,
-        [ctx.field.id]: { invalid: false },
-      });
-    }
+    const isValid = newValue ? isValidPhoneNumber(String(newValue)) : true;
 
-    if (fieldType === "json") {
+    ctx.updatePluginParameters({
+      ...ctx.plugin.attributes.parameters,
+      [ctx.field.id]: { invalid: !isValid },
+    });
+
+    if (fieldType === "json" && newValue) {
       const parsedValue = parsePhoneNumber(String(newValue));
-      const jsonValue = JSON.stringify(parsedValue);
-      await ctx.setFieldValue(ctx.fieldPath, jsonValue);
+      await ctx.setFieldValue(ctx.fieldPath, JSON.stringify(parsedValue));
       return;
     }
 
@@ -65,32 +76,44 @@ export default function FieldExtension({ ctx }: Props) {
   };
 
   useEffect(() => {
-    if (fieldType === "json") {
-      const parsedValue = JSON.parse(String(rawValue));
-      if (parsedValue) {
-        setValue(parsedValue.number);
+    if (fieldType === "json" && rawValue) {
+      try {
+        const parsed = JSON.parse(String(rawValue));
+        setValue(parsed?.number);
+      } catch (e) {
+        setValue(undefined);
       }
     } else {
       setValue(rawValue);
     }
-  }, [rawValue]);
+  }, [rawValue, fieldType]);
 
   return (
     <Canvas ctx={ctx}>
-      <PhoneInput
-        id={ctx.fieldPath}
-        value={value}
-        onChange={handleChange}
-        inputComponent={PhoneInputAdapter}
-        countrySelectComponent={CountrySelectAdapter}
-        international={true}
-        countries={countries}
-        defaultCountry={parameters.defaultCountry?.value}
-      />
+      <div
+        ref={containerRef}
+        style={{ overflow: 'visible', position: 'relative' }}
+      >
+        <PhoneInput
+          id={ctx.fieldPath}
+          value={value}
+          onChange={handleChange}
+          inputComponent={PhoneInputAdapter}
+          countrySelectComponent={CountrySelectAdapter}
+          // Pass resize handlers safely via countrySelectProps to avoid console warnings
+          countrySelectProps={{
+            onMenuOpen: handleMenuOpen,
+            onMenuClose: handleMenuClose,
+          }}
+          international={true}
+          countries={countries}
+          defaultCountry={parameters.defaultCountry?.value}
+        />
 
-      {value && !isValidPhoneNumber(String(value)) && (
-        <FieldError>Phone number is invalid</FieldError>
-      )}
+        {value && !isValidPhoneNumber(String(value)) && (
+          <FieldError>Phone number is invalid</FieldError>
+        )}
+      </div>
     </Canvas>
   );
 }

--- a/src/entrypoints/FieldExtension.tsx
+++ b/src/entrypoints/FieldExtension.tsx
@@ -30,15 +30,14 @@ export default function FieldExtension({ ctx }: Props) {
 
   const containerRef = useRef<HTMLDivElement>(null);
 
-  /**
-   * Manually manage iframe height when the country dropdown opens.
-   */
   const handleMenuOpen = useCallback(() => {
     if (containerRef.current) {
       const currentHeight = containerRef.current.getBoundingClientRect().height;
 
       stopAutoResizer();
 
+      // Ensure the canvas is tall enough to show the entire menu (min 360px)
+      // and account for container padding (20px).
       setHeight(Math.max(currentHeight, 360) + 10);
     }
   }, [stopAutoResizer, setHeight]);
@@ -81,6 +80,7 @@ export default function FieldExtension({ ctx }: Props) {
         const parsed = JSON.parse(String(rawValue));
         setValue(parsed?.number);
       } catch (e) {
+        console.error(e);
         setValue(undefined);
       }
     } else {
@@ -100,7 +100,6 @@ export default function FieldExtension({ ctx }: Props) {
           onChange={handleChange}
           inputComponent={PhoneInputAdapter}
           countrySelectComponent={CountrySelectAdapter}
-          // Pass resize handlers safely via countrySelectProps to avoid console warnings
           countrySelectProps={{
             onMenuOpen: handleMenuOpen,
             onMenuClose: handleMenuClose,

--- a/src/entrypoints/FieldExtensionConfigScreen.tsx
+++ b/src/entrypoints/FieldExtensionConfigScreen.tsx
@@ -9,16 +9,18 @@ type Props = {
   ctx: RenderManualFieldExtensionConfigScreenCtx;
 };
 
+const MAX_MENU_HEIGHT = 200;
+
 export default function FieldExtensionConfigScreen({ ctx }: Props) {
   const { setHeight, startAutoResizer, stopAutoResizer } = ctx;
   const parameters = ctx.parameters as Parameters;
   const containerRef = useRef<HTMLDivElement>(null);
 
   const handleMenuOpen = useCallback(() => {
+    stopAutoResizer();
     if (containerRef.current) {
       const currentHeight = containerRef.current.getBoundingClientRect().height;
-      stopAutoResizer();
-      setHeight(Math.max(currentHeight, 360) + 10);
+      setHeight(currentHeight + MAX_MENU_HEIGHT);
     }
   }, [stopAutoResizer, setHeight]);
 
@@ -78,6 +80,8 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
               isMulti: true,
               options: countries,
               isDisabled: excludeCountries.length > 0,
+              menuPosition: 'fixed' as const,
+              maxMenuHeight: MAX_MENU_HEIGHT,
               onMenuOpen: handleMenuOpen,
               onMenuClose: handleMenuClose,
             }}
@@ -97,6 +101,8 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
               isMulti: true,
               options: countries,
               isDisabled: includeCountries.length > 0,
+              menuPosition: 'fixed' as const,
+              maxMenuHeight: MAX_MENU_HEIGHT,
               onMenuOpen: handleMenuOpen,
               onMenuClose: handleMenuClose,
             }}
@@ -109,6 +115,8 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
             name="default_country"
             selectInputProps={{
               options: defaultCountryOptions,
+              menuPosition: 'fixed' as const,
+              maxMenuHeight: MAX_MENU_HEIGHT,
               onMenuOpen: handleMenuOpen,
               onMenuClose: handleMenuClose,
             }}

--- a/src/entrypoints/FieldExtensionConfigScreen.tsx
+++ b/src/entrypoints/FieldExtensionConfigScreen.tsx
@@ -1,6 +1,6 @@
 import { RenderManualFieldExtensionConfigScreenCtx } from "datocms-plugin-sdk";
 import { Canvas, Form, SelectField } from "datocms-react-ui";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { getCountries } from "react-phone-number-input";
 import { Parameters } from "../types/parameters";
 
@@ -10,7 +10,21 @@ type Props = {
 };
 
 export default function FieldExtensionConfigScreen({ ctx }: Props) {
+  const { setHeight, startAutoResizer, stopAutoResizer } = ctx;
   const parameters = ctx.parameters as Parameters;
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleMenuOpen = useCallback(() => {
+    if (containerRef.current) {
+      const currentHeight = containerRef.current.getBoundingClientRect().height;
+      stopAutoResizer();
+      setHeight(Math.max(currentHeight, 360) + 10);
+    }
+  }, [stopAutoResizer, setHeight]);
+
+  const handleMenuClose = useCallback(() => {
+    startAutoResizer();
+  }, [startAutoResizer]);
   const countries = getCountries().map((country) => ({
     value: country,
     label: country,
@@ -49,52 +63,60 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
 
   return (
     <Canvas ctx={ctx}>
-      <Form>
-        <SelectField
-          id="include_countries"
-          label="Include countries"
-          name="include_countries"
-          hint={
-            excludeCountries.length > 0
-              ? "Empty Exclude countries if you want to include countries"
-              : "Leave empty to include all countries"
-          }
-          selectInputProps={{
-            isMulti: true,
-            options: countries,
-            isDisabled: excludeCountries.length > 0,
-          }}
-          value={includeCountries}
-          onChange={(value) => setIncludeCountries(value)}
-        />
-        <SelectField
-          id="exclude_countries"
-          label="Exclude countries"
-          name="exclude_countries"
-          hint={
-            includeCountries.length > 0
-              ? "Empty Include countries if you want to exclude countries"
-              : "Leave empty to exclude no countries"
-          }
-          selectInputProps={{
-            isMulti: true,
-            options: countries,
-            isDisabled: includeCountries.length > 0,
-          }}
-          value={excludeCountries}
-          onChange={(value) => setExcludeCountries(value)}
-        />
-        <SelectField
-          id="default_country"
-          label="Default country"
-          name="default_country"
-          selectInputProps={{
-            options: defaultCountryOptions,
-          }}
-          value={defaultCountry}
-          onChange={(value) => setDefaultCountry(value as Parameters['defaultCountry'])}
-        />
-      </Form>
+      <div ref={containerRef}>
+        <Form>
+          <SelectField
+            id="include_countries"
+            label="Include countries"
+            name="include_countries"
+            hint={
+              excludeCountries.length > 0
+                ? "Empty Exclude countries if you want to include countries"
+                : "Leave empty to include all countries"
+            }
+            selectInputProps={{
+              isMulti: true,
+              options: countries,
+              isDisabled: excludeCountries.length > 0,
+              onMenuOpen: handleMenuOpen,
+              onMenuClose: handleMenuClose,
+            }}
+            value={includeCountries}
+            onChange={(value) => setIncludeCountries(value)}
+          />
+          <SelectField
+            id="exclude_countries"
+            label="Exclude countries"
+            name="exclude_countries"
+            hint={
+              includeCountries.length > 0
+                ? "Empty Include countries if you want to exclude countries"
+                : "Leave empty to exclude no countries"
+            }
+            selectInputProps={{
+              isMulti: true,
+              options: countries,
+              isDisabled: includeCountries.length > 0,
+              onMenuOpen: handleMenuOpen,
+              onMenuClose: handleMenuClose,
+            }}
+            value={excludeCountries}
+            onChange={(value) => setExcludeCountries(value)}
+          />
+          <SelectField
+            id="default_country"
+            label="Default country"
+            name="default_country"
+            selectInputProps={{
+              options: defaultCountryOptions,
+              onMenuOpen: handleMenuOpen,
+              onMenuClose: handleMenuClose,
+            }}
+            value={defaultCountry}
+            onChange={(value) => setDefaultCountry(value as Parameters['defaultCountry'])}
+          />
+        </Form>
+      </div>
     </Canvas>
   );
 }

--- a/src/entrypoints/FieldExtensionConfigScreen.tsx
+++ b/src/entrypoints/FieldExtensionConfigScreen.tsx
@@ -9,8 +9,6 @@ type Props = {
   ctx: RenderManualFieldExtensionConfigScreenCtx;
 };
 
-const MAX_MENU_HEIGHT = 200;
-
 export default function FieldExtensionConfigScreen({ ctx }: Props) {
   const { setHeight, startAutoResizer, stopAutoResizer } = ctx;
   const parameters = ctx.parameters as Parameters;
@@ -20,7 +18,7 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
     stopAutoResizer();
     if (containerRef.current) {
       const currentHeight = containerRef.current.getBoundingClientRect().height;
-      setHeight(currentHeight + MAX_MENU_HEIGHT);
+      setHeight(currentHeight + 330);
     }
   }, [stopAutoResizer, setHeight]);
 
@@ -80,8 +78,6 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
               isMulti: true,
               options: countries,
               isDisabled: excludeCountries.length > 0,
-              menuPosition: 'fixed' as const,
-              maxMenuHeight: MAX_MENU_HEIGHT,
               onMenuOpen: handleMenuOpen,
               onMenuClose: handleMenuClose,
             }}
@@ -101,8 +97,6 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
               isMulti: true,
               options: countries,
               isDisabled: includeCountries.length > 0,
-              menuPosition: 'fixed' as const,
-              maxMenuHeight: MAX_MENU_HEIGHT,
               onMenuOpen: handleMenuOpen,
               onMenuClose: handleMenuClose,
             }}
@@ -115,8 +109,6 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
             name="default_country"
             selectInputProps={{
               options: defaultCountryOptions,
-              menuPosition: 'fixed' as const,
-              maxMenuHeight: MAX_MENU_HEIGHT,
               onMenuOpen: handleMenuOpen,
               onMenuClose: handleMenuClose,
             }}

--- a/src/entrypoints/FieldExtensionConfigScreen.tsx
+++ b/src/entrypoints/FieldExtensionConfigScreen.tsx
@@ -18,6 +18,8 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
     stopAutoResizer();
     if (containerRef.current) {
       const currentHeight = containerRef.current.getBoundingClientRect().height;
+
+      // Ensure the canvas is tall enough to show the entire menu (min 330px)
       setHeight(currentHeight + 330);
     }
   }, [stopAutoResizer, setHeight]);
@@ -30,9 +32,15 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
     label: country,
   }));
   const [defaultCountryOptions, setDefaultCountryOptions] = useState(countries);
-  const [includeCountries, setIncludeCountries] = useState<Parameters['includeCountries']>(parameters.includeCountries || []);
-  const [excludeCountries, setExcludeCountries] = useState<Parameters['excludeCountries']>(parameters.excludeCountries || []);
-  const [defaultCountry, setDefaultCountry] = useState<Parameters['defaultCountry']>(parameters.defaultCountry);
+  const [includeCountries, setIncludeCountries] = useState<
+    Parameters["includeCountries"]
+  >(parameters.includeCountries || []);
+  const [excludeCountries, setExcludeCountries] = useState<
+    Parameters["excludeCountries"]
+  >(parameters.excludeCountries || []);
+  const [defaultCountry, setDefaultCountry] = useState<
+    Parameters["defaultCountry"]
+  >(parameters.defaultCountry);
 
   useEffect(() => {
     ctx.setParameters({
@@ -113,7 +121,9 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
               onMenuClose: handleMenuClose,
             }}
             value={defaultCountry}
-            onChange={(value) => setDefaultCountry(value as Parameters['defaultCountry'])}
+            onChange={(value) =>
+              setDefaultCountry(value as Parameters["defaultCountry"])
+            }
           />
         </Form>
       </div>


### PR DESCRIPTION
## Changes

- add height fix for iframe when menu is opened
- add some small overall improvements

The fix for the config screen is not ideal. I don't really have a robust solution for this now, but it's better than it was before. 

## How to test

1. Clone repository
2. Run npm ci
3. Run npm run dev
4. Go to DatoCMS -> dato-plugin-tryout -> Content -> Plugin try-out -> Plugin Phone Number
5. Open the country selector. Gap should be limited to the select menu.
6. Go to DatoCMS -> dato-plugin-tryout -> Schema -> Models -> Plugin Phone Number
7. Edit a field.
8. Open tab Presentation
9. Open a select menu. The gap should be within reasonable limits.