### PR TITLE
Fix iframe height expanding when select menus open

### DIFF
--- a/src/entrypoints/FieldExtensionConfigScreen.tsx
+++ b/src/entrypoints/FieldExtensionConfigScreen.tsx
@@ -9,16 +9,18 @@ type Props = {
   ctx: RenderManualFieldExtensionConfigScreenCtx;
 };
 
+const MAX_MENU_HEIGHT = 200;
+
 export default function FieldExtensionConfigScreen({ ctx }: Props) {
   const { setHeight, startAutoResizer, stopAutoResizer } = ctx;
   const parameters = ctx.parameters as Parameters;
   const containerRef = useRef<HTMLDivElement>(null);
 
   const handleMenuOpen = useCallback(() => {
+    stopAutoResizer();
     if (containerRef.current) {
       const currentHeight = containerRef.current.getBoundingClientRect().height;
-      stopAutoResizer();
-      setHeight(Math.max(currentHeight, 360) + 10);
+      setHeight(currentHeight + MAX_MENU_HEIGHT);
     }
   }, [stopAutoResizer, setHeight]);
 
@@ -78,6 +80,8 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
               isMulti: true,
               options: countries,
               isDisabled: excludeCountries.length > 0,
+              menuPosition: 'fixed' as const,
+              maxMenuHeight: MAX_MENU_HEIGHT,
               onMenuOpen: handleMenuOpen,
               onMenuClose: handleMenuClose,
             }}
@@ -97,6 +101,8 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
               isMulti: true,
               options: countries,
               isDisabled: includeCountries.length > 0,
+              menuPosition: 'fixed' as const,
+              maxMenuHeight: MAX_MENU_HEIGHT,
               onMenuOpen: handleMenuOpen,
               onMenuClose: handleMenuClose,
             }}
@@ -109,6 +115,8 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
             name="default_country"
             selectInputProps={{
               options: defaultCountryOptions,
+              menuPosition: 'fixed' as const,
+              maxMenuHeight: MAX_MENU_HEIGHT,
               onMenuOpen: handleMenuOpen,
               onMenuClose: handleMenuClose,
             }}


### PR DESCRIPTION
## Summary
- **Field extension**: Add menu open/close handlers to `CountrySelectAdapter` that stop the auto-resizer on open and restore it on close, preventing the iframe from expanding to fit all 240+ country options
- **Config screen**: Use `menuPosition: 'fixed'` on all select fields to prevent the DatoCMS auto-resizer's `MutationObserver` from measuring dropdown items before `onMenuOpen` can stop it (race condition fix)
- Fix height formula from `Math.max(currentHeight, 360) + 10` to `currentHeight + MAX_MENU_HEIGHT` so the iframe has enough room for the dropdown without being unnecessarily large

## Test plan
- [ ] Open the plugin config screen and verify the iframe does not expand massively when opening any of the 3 select dropdowns
- [ ] Verify dropdown items are visible and scrollable within the menu
- [ ] Verify iframe shrinks back to normal after closing a dropdown
- [ ] Open the field extension country select and verify the same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)